### PR TITLE
run management container as non-root (#19)

### DIFF
--- a/wis2-gdc-management/Dockerfile
+++ b/wis2-gdc-management/Dockerfile
@@ -25,7 +25,7 @@ LABEL maintainer="tomkralidis@gmail.com"
 
 ENV TZ="Etc/UTC" \
     DEBIAN_FRONTEND="noninteractive" \
-    DEBIAN_PACKAGES="bash cron curl git python3-pip python3-setuptools vim"
+    DEBIAN_PACKAGES="bash cron curl git python3-pip python3-setuptools sudo vim"
 
 # copy the app
 COPY ./ /app
@@ -48,7 +48,9 @@ RUN apt-get update -y && \
     chmod 0644 /var/spool/cron/crontabs/wis2-gdc && \
     crontab /var/spool/cron/crontabs/wis2-gdc && \
     # add wis2-gdc user
-    useradd -ms /bin/bash wis2-gdc
+    useradd -ms /bin/bash wis2-gdc && \
+    adduser wis2-gdc sudo && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 USER wis2-gdc
 

--- a/wis2-gdc-management/Dockerfile
+++ b/wis2-gdc-management/Dockerfile
@@ -31,7 +31,7 @@ ENV TZ="Etc/UTC" \
 COPY ./ /app
 
 # add to crontab
-COPY ./docker/wis2-gdc-management.cron /etc/cron.d/wis2-gdc-management.cron
+COPY ./docker/wis2-gdc-management.cron /var/spool/cron/crontabs/wis2-gdc
 
 RUN apt-get update -y && \
     # install dependencies
@@ -45,7 +45,11 @@ RUN apt-get update -y && \
     apt autoremove -y && \
     apt-get -q clean && \
     rm -rf /var/lib/apt/lists/* && \
-    chmod 0644 /etc/cron.d/wis2-gdc-management.cron && \
-    crontab /etc/cron.d/wis2-gdc-management.cron
+    chmod 0644 /var/spool/cron/crontabs/wis2-gdc && \
+    crontab /var/spool/cron/crontabs/wis2-gdc && \
+    # add wis2-gdc user
+    useradd -ms /bin/bash wis2-gdc
+
+USER wis2-gdc
 
 ENTRYPOINT [ "/app/docker/entrypoint.sh" ]

--- a/wis2-gdc-management/docker/entrypoint.sh
+++ b/wis2-gdc-management/docker/entrypoint.sh
@@ -24,10 +24,12 @@
 
 echo "START /entrypoint.sh"
 
-printenv | grep -v "no_proxy" >> /etc/environment
+printenv | grep -v "no_proxy" > /tmp/environment
+sudo sh -c 'cat /tmp/environment >> /etc/environment'
+rm -f /tmp/environment
 
 echo "Starting cron"
-service cron start
+sudo service cron start
 service cron status
 
 echo "Caching WNM schema"

--- a/wis2-gdc-management/docker/wis2-gdc-management.cron
+++ b/wis2-gdc-management/docker/wis2-gdc-management.cron
@@ -1,1 +1,1 @@
-0 0 * * * su -c "wis2-gdc archive $WIS2_GDC_METADATA_ARCHIVE_ZIPFILE" > /proc/1/fd/1 2>/proc/1/fd/2
+0 0 * * * wis2-gdc archive $WIS2_GDC_METADATA_ARCHIVE_ZIPFILE > /proc/1/fd/1 2>/proc/1/fd/2


### PR DESCRIPTION
Fixes #19 (`wis2-gdc-management` container now runs as user `wis2-gdc`).

@nbuttdwd can you test?