### PR TITLE
add WCMP2 unregister functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ wis2-gdc register /path/to/dir/of/wcmp2-files
 wis2-gdc register https://example.org/wcmp2-file.json
 
 # deleting metadata by identifier
-wis2-gdc unregister urn:wmo:md:ca-eccc-msc:id123
+wis2-gdc unregister "urn:wmo:md:ca-eccc-msc:id123"
 
 # loading metadata from a known harvest endpoint
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ wis2-gdc register /path/to/dir/of/wcmp2-files
 # loading metadata manually (from URL)
 wis2-gdc register https://example.org/wcmp2-file.json
 
+# deleting metadata by identifier
+wis2-gdc unregister urn:wmo:md:ca-eccc-msc:id123
+
 # loading metadata from a known harvest endpoint
 
 # load from wis2box known deployments (https://demo.wis2box.wis.wmo.int)

--- a/wis2-gdc-management/wis2_gdc/__init__.py
+++ b/wis2-gdc-management/wis2_gdc/__init__.py
@@ -21,7 +21,7 @@
 
 import click
 
-from wis2_gdc.registrar import register, setup, teardown
+from wis2_gdc.registrar import register, setup, teardown, unregister
 from wis2_gdc.archive import archive
 from wis2_gdc.sync import sync
 
@@ -38,6 +38,7 @@ def cli():
 
 cli.add_command(setup)
 cli.add_command(teardown)
+cli.add_command(unregister)
 cli.add_command(register)
 cli.add_command(sync)
 cli.add_command(archive)

--- a/wis2-gdc-management/wis2_gdc/backend/base.py
+++ b/wis2-gdc-management/wis2_gdc/backend/base.py
@@ -50,7 +50,7 @@ class BaseBackend(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def save(self, record: dict) -> None:
+    def save_record(self, record: dict) -> None:
         """
         Upsert a resource to a backend
 
@@ -79,6 +79,18 @@ class BaseBackend(ABC):
         :param identifier: `str` of record identifier
 
         :returns: `bool` of whether record exists in backend
+        """
+
+        raise NotImplementedError()
+
+    @abstractmethod
+    def delete_record(self, identifier: str) -> None:
+        """
+        Delete a record from the backend
+
+        :param identifier: `str` of record identifier
+
+        :returns: `None`
         """
 
         raise NotImplementedError()

--- a/wis2-gdc-management/wis2_gdc/backend/elastic.py
+++ b/wis2-gdc-management/wis2_gdc/backend/elastic.py
@@ -153,9 +153,13 @@ class ElasticsearchBackend(BaseBackend):
             LOGGER.debug(f'Deleting index {self.index_name}')
             self.es.indices.delete(index=self.index_name)
 
-    def save(self, record: dict) -> None:
+    def save_record(self, record: dict) -> None:
         LOGGER.debug(f"Indexing record {record['id']}")
         self.es.index(index=self.index_name, id=record['id'], body=record)
+
+    def delete_record(self, identifier: str) -> None:
+        LOGGER.debug(f"Deleting record {identifier}")
+        self.es.delete(index=self.index_name, id=identifier)
 
     def exists(self) -> bool:
         LOGGER.debug('Checking whether backend exists')

--- a/wis2-gdc-management/wis2_gdc/backend/ogcapi_records.py
+++ b/wis2-gdc-management/wis2_gdc/backend/ogcapi_records.py
@@ -38,7 +38,7 @@ class OGCAPIRecordsBackend(BaseBackend):
         self.conn = Records(env.API_URL)
         self.collection = 'discovery-metadata'
 
-    def save(self):
+    def save_record(self):
 
         ttype = 'create'
 

--- a/wis2-gdc-management/wis2_gdc/hook.py
+++ b/wis2-gdc-management/wis2_gdc/hook.py
@@ -30,10 +30,19 @@ LOGGER = logging.getLogger(__name__)
 
 class DiscoveryMetadataHook(Hook):
     def execute(self, topic: str, msg_dict: dict) -> None:
+        wcmp2_dict = None
+
         LOGGER.debug('Discovery metadata hook execution begin')
         r = Registrar()
 
-        wcmp2_dict = r.get_wcmp2(msg_dict, topic)
+        try:
+            wcmp2_dict = r.get_wcmp2(msg_dict, topic)
+        except (IndexError, KeyError):
+            is_deletion = list(filter(lambda d: d['rel'] == 'deletion',
+                                      msg_dict['links']))
+
+            if is_deletion:
+                r.delete_record(topic, msg_dict)
 
         if wcmp2_dict is not None:
             r.register(wcmp2_dict, topic)

--- a/wis2-gdc-management/wis2_gdc/registrar.py
+++ b/wis2-gdc-management/wis2_gdc/registrar.py
@@ -453,6 +453,8 @@ def teardown(ctx, bypass, verbosity='NOTSET'):
     LOGGER.debug(f'Backend: {backend}')
     backend.teardown()
 
+    click.echo('Done')
+
 
 @click.command()
 @click.pass_context
@@ -490,6 +492,8 @@ def register(ctx, path, verbosity='NOTSET'):
 
         r.register(metadata)
 
+    click.echo('Done')
+
 
 @click.command()
 @click.pass_context
@@ -499,5 +503,11 @@ def unregister(ctx, identifier, verbosity='NOTSET'):
     """Unregister discovery metadata"""
 
     click.echo(f'Unregistering {identifier}')
-    r = Registrar()
-    r.delete_record(identifier)
+    backend = BACKENDS[BACKEND_TYPE]({'connection': BACKEND_CONNECTION})
+    try:
+        LOGGER.debug(f'Backend: {backend}')
+        backend.delete_record(identifier)
+    except Exception:
+        click.echo('record not found')
+
+    click.echo('Done')


### PR DESCRIPTION
Adds unregister functionality, triggered by a WNM metadata deletion ([example](https://github.com/wmo-im/wis2-notification-message/blob/main/examples/example4.json)), or by running `wis2-gdc unregister <WCMP2_ID>`.

@antje-s / @nbuttdwd if you can test that would be greatly appreciated.